### PR TITLE
replace deprecated std::env::home_dir() with dirs::home_dir()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ build = "build.rs"
 objc-foundation = "0.1.1"
 chrono = "0.4.0"
 failure = "0.1.1"
+dirs = "1.0"
 
 [build-dependencies]
 cc = "1.0.17"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@ pub mod error;
 use chrono::offset::*;
 use error::*;
 use objc_foundation::{INSString, NSString};
-use std::env;
 use std::ops::Deref;
 use std::path::PathBuf;
 
@@ -155,7 +154,7 @@ pub fn set_application(bundle_ident: &str) -> NotificationResult<()> {
 }
 
 fn check_sound(sound_name: &str) -> bool {
-    env::home_dir()
+    dirs::home_dir()
         .map(|path| path.join("/Library/Sounds/"))
         .into_iter()
         .chain(


### PR DESCRIPTION
While compiling the latest master branch I got the following deprecation warning
```
warning: use of deprecated item 'std::env::home_dir': This function's behavior is unexpected and probably not what you want. Consider using the home_dir function from https://crates.io/crates/dirs instead.
   --> src/lib.rs:158:5
    |
158 |     env::home_dir()
    |     ^^^^^^^^^^^^^
    |
    = note: #[warn(deprecated)] on by default
```

I ran the unittests and all passed, but am not sure, if this change is covered by the tests.

One other unrelated question is, if you plan to switch to Rust edition 2018.
If so, I could probably provide a pullrequest for this, too.