### PR TITLE
update default application behavior

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mac-notification-sys"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Felix Döring <development@felixdoering.com>", "Hendrik Sollich <hendrik@hoodie.de>"]
 description = "Thin wrapper around macOS Notifications."
 

--- a/examples/default_app.rs
+++ b/examples/default_app.rs
@@ -1,0 +1,10 @@
+extern crate mac_notification_sys;
+use mac_notification_sys::*;
+
+fn main() {
+    // not setting the application bundle here, should use default
+    // let bundle = get_bundle_identifier_or_default("use_default");
+    // set_application(&bundle).unwrap();
+    
+    send_notification("title", &None, "message", &None).unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,11 @@ pub fn send_notification(
     };
 
     unsafe {
+        if !APPLICATION_SET {
+            let bundle = get_bundle_identifier_or_default("use_default");
+            set_application(&bundle).unwrap();
+            APPLICATION_SET = true;
+        }
         ensure!(
             sys::sendNotification(
                 NSString::from_str(title).deref(),
@@ -123,9 +128,9 @@ pub fn send_notification(
 }
 
 /// Search for a possible BundleIdentifier of a given appname.
-/// Defaults to "com.apple.Terminal" if no BundleIdentifier is found.
+/// Defaults to "com.apple.Finder" if no BundleIdentifier is found.
 pub fn get_bundle_identifier_or_default(app_name: &str) -> String {
-    get_bundle_identifier(app_name).unwrap_or_else(|| "com.apple.Terminal".to_string())
+    get_bundle_identifier(app_name).unwrap_or_else(|| "com.apple.Finder".to_string())
 }
 
 /// Search for a BundleIdentifier of an given appname.

--- a/tests/application.rs
+++ b/tests/application.rs
@@ -12,5 +12,5 @@ fn set_application_again() {
 #[test]
 fn get_default_identifier() {
     let bundle = get_bundle_identifier_or_default("thisappdoesnotexist");
-    assert_eq!(bundle, "com.apple.Terminal");
+    assert_eq!(bundle, "com.apple.Finder");
 }


### PR DESCRIPTION
Thanks for your work on this crate. This PR resolves two minor issues. 

First, on my machine using bundle identifier "com.apple.Terminal" silently fails to send notifications. This PR changes the default to "com.apple.Finder" which resolves the issue.

Second, calling `send_message` without first calling `set_application` silently fails on my machine. This PR sets the application automatically if it hasn't been set before the user calls `send_message`. 