### PR TITLE
Replace the deprecated dirs with dirs_next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ build = "build.rs"
 objc-foundation = "0.1.1"
 objc_id = "0.1.1"
 chrono = "0.4.0"
-dirs = "1.0"
+dirs-next = "2.0.0"
 
 [build-dependencies]
 cc = "1.0.17"

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -255,7 +255,7 @@ impl NotificationResponse {
 }
 
 pub(crate) fn check_sound(sound_name: &str) -> bool {
-    dirs::home_dir()
+    dirs_next::home_dir()
         .map(|path| path.join("/Library/Sounds/"))
         .into_iter()
         .chain(


### PR DESCRIPTION
The `dirs` crate is no longer maintained and it is reccomended to switch
to the `dirs-next` crate. See [RUSTSEC-2020-0053](https://rustsec.org/advisories/RUSTSEC-2020-0053.html).

Closes #26