### PR TITLE
replace chrono with time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ build = "build.rs"
 [dependencies]
 objc-foundation = "0.1.1"
 objc_id = "0.1.1"
-chrono = "0.4.0"
+time = "0.3"
 dirs-next = "2.0.0"
 
 [build-dependencies]

--- a/examples/date.rs
+++ b/examples/date.rs
@@ -1,8 +1,7 @@
-use chrono::offset::*;
 use mac_notification_sys::*;
 
 fn main() {
-    let stamp = Utc::now().timestamp() as f64 + 5.;
+    let stamp = time::OffsetDateTime::now_utc().unix_timestamp() as f64 + 5.;
     println!("{:?}", stamp);
     let bundle = get_bundle_identifier_or_default("firefox");
     set_application(&bundle).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 pub mod error;
 mod notification;
 
-use chrono::offset::*;
 use error::{ApplicationError, NotificationError, NotificationResult};
 pub use notification::{MainButton, Notification, NotificationResponse};
 use objc_foundation::{INSDictionary, INSString, NSString};
@@ -58,7 +57,7 @@ pub fn send_notification(
     if let Some(options) = &options {
         if let Some(delivery_date) = options.delivery_date {
             ensure!(
-                delivery_date >= Utc::now().timestamp() as f64,
+                delivery_date >= time::OffsetDateTime::now_utc().unix_timestamp() as f64,
                 NotificationError::ScheduleInThePast
             );
         }
@@ -110,7 +109,10 @@ pub fn get_bundle_identifier(app_name: &str) -> Option<String> {
 /// Set the application which delivers or schedules a notification
 pub fn set_application(bundle_ident: &str) -> NotificationResult<()> {
     unsafe {
-        ensure!(!APPLICATION_SET, ApplicationError::AlreadySet(bundle_ident.into()));
+        ensure!(
+            !APPLICATION_SET,
+            ApplicationError::AlreadySet(bundle_ident.into())
+        );
         ensure!(
             sys::setApplication(NSString::from_str(bundle_ident).deref()),
             ApplicationError::CouldNotSet(bundle_ident.into())

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -115,8 +115,7 @@ impl<'a> Notification<'a> {
     ///
     /// ```no_run
     /// # use mac_notification_sys::*;
-    /// # use chrono::offset::*;
-    /// let stamp = Utc::now().timestamp() as f64 + 5.;
+    /// let stamp = time::OffsetDateTime::now_utc().unix_timestamp() as f64 + 5.;
     /// let _ = Notification::new().delivery_date(stamp);
     /// ```
     pub fn delivery_date(&mut self, delivery_date: f64) -> &mut Self {

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -1,10 +1,9 @@
-use chrono::offset::*;
 use mac_notification_sys::*;
 
 #[test]
 #[should_panic]
 fn dont_schedule_in_past() {
-    let stamp = Utc::now().timestamp() as f64 - 5.;
+    let stamp = time::OffsetDateTime::now_utc().unix_timestamp() as f64 - 5.;
     let _sent = send_notification(
         "Danger",
         Some("Will Robinson"),


### PR DESCRIPTION
The chrono crate uses time v0.1, which has some security issues, see [RUSTSEC-2020-0159](RUSTSEC-2020-0159) and [https://rustsec.org/advisories/RUSTSEC-2020-0071.html](https://rustsec.org/advisories/RUSTSEC-2020-0071.html). I'd love to see this project using time instead of chrono since it just affects a single line of code, making the crate more secure and up to date.