### PR TITLE
feat: provide builder pattern

### DIFF
--- a/examples/send_notification.rs
+++ b/examples/send_notification.rs
@@ -1,0 +1,22 @@
+use mac_notification_sys::*;
+
+fn main() {
+    let bundle = get_bundle_identifier_or_default("firefox");
+    set_application(&bundle).unwrap();
+
+    send_notification(
+        "Danger",
+        Some("Will Robinson"),
+        "Run away as fast as you can",
+        None,
+    )
+    .unwrap();
+
+    send_notification(
+        "NOW",
+        None,
+        "Without subtitle",
+        Some(Notification::new().sound("Submarine")),
+    )
+    .unwrap();
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -4,19 +4,17 @@ fn main() {
     let bundle = get_bundle_identifier_or_default("firefox");
     set_application(&bundle).unwrap();
 
-    send_notification(
-        "Danger",
-        Some("Will Robinson"),
-        "Run away as fast as you can",
-        None,
-    )
-    .unwrap();
+    Notification::default()
+        .title("Danger")
+        .subtitle("Will Robinson")
+        .message("Run away as fast as you can")
+        .send()
+        .unwrap();
 
-    send_notification(
-        "NOW",
-        None,
-        "Without subtitle",
-        Some(Notification::new().sound("Submarine")),
-    )
-    .unwrap();
+    Notification::default()
+        .title("NOW")
+        .message("Without subtitle")
+        .sound("Submarine")
+        .send()
+        .unwrap();
 }

--- a/examples/sound.rs
+++ b/examples/sound.rs
@@ -1,0 +1,16 @@
+use mac_notification_sys::*;
+
+fn main() {
+    Notification::default()
+        .title("🔔")
+        .message("Ping")
+        .sound("Ping")
+        .send()
+        .unwrap();
+    Notification::default()
+        .title("🐟")
+        .message("Submarine")
+        .sound("Submarine")
+        .send()
+        .unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! A very thin wrapper around NSNotifications
-#![deny(
+#![warn(
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
@@ -48,6 +48,7 @@ mod sys {
 /// // deliver a silent notification
 /// let _ = send_notification("Title", None, "This is the body", None).unwrap();
 /// ```
+// #[deprecated(note="use `Notification::send`")]
 pub fn send_notification(
     title: &str,
     subtitle: Option<&str>,


### PR DESCRIPTION
hi there,
while integrating the 0.4.0 release I found it not very ergonomic.
now there is a similar builder api as notify-rust has.

thank you