### PR TITLE
Fix linked objctive-C symbols on old macOS versions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,29 @@
 extern crate cc;
+use std::env;
+
+const DEPLOYMENT_TARGET_VAR: &str = "MACOSX_DEPLOYMENT_TARGET";
 
 fn main() {
     if cfg!(target_os = "macos") {
+        let min_version = match env::var(DEPLOYMENT_TARGET_VAR) {
+            Ok(ver) => ver,
+            Err(_) => String::from(match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
+                "x86_64" => "10.8", // NSUserNotificationCenter first showed up here.
+                "aarch64" => "11.0", // Apple silicon started here.
+                arch => panic!("unknown arch: {}", arch),
+            }),
+        };
+
         cc::Build::new()
             .file("objc/notify.m")
             .flag("-fmodules")
             .flag("-Wno-deprecated-declarations")
+            // `cc` doesn't try to pick up on this automatically, but `clang` needs it to
+            // generate a "correct" Objective-C symbol table which better matches XCode.
+            // See https://github.com/h4llow3En/mac-notification-sys/issues/45.
+            .flag(&format!("-mmacos-version-min={}", min_version))
             .compile("notify");
+
+        println!("cargo:rerun-if-env-changed={}", DEPLOYMENT_TARGET_VAR);
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ fn main() {
         cc::Build::new()
             .file("objc/notify.m")
             .flag("-fmodules")
-            .warnings(false)
+            .flag("-Wno-deprecated-declarations")
             .compile("notify");
     }
 }


### PR DESCRIPTION
Closes #45

With these changes, the symbol table for binaries using this crate looks more correct for older macOS builds. By default on a M1:
```
~/x/leak_hunting [master +4 ~0 -0 !] ▶ nm ./target/debug/leak_hunting | rg _OBJC_CLASS_
                 U _OBJC_CLASS_$_NSAppleScript
                 U _OBJC_CLASS_$_NSBundle
                 U _OBJC_CLASS_$_NSConstantDictionary
                 U _OBJC_CLASS_$_NSConstantIntegerNumber
                 U _OBJC_CLASS_$_NSDate
                 U _OBJC_CLASS_$_NSDictionary
                 U _OBJC_CLASS_$_NSImage
                 U _OBJC_CLASS_$_NSObject
                 U _OBJC_CLASS_$_NSRunLoop
                 U _OBJC_CLASS_$_NSString
                 U _OBJC_CLASS_$_NSThread
                 U _OBJC_CLASS_$_NSURL
                 U _OBJC_CLASS_$_NSUserNotification
                 U _OBJC_CLASS_$_NSUserNotificationCenter
0000000100068748 S _OBJC_CLASS_$_NotificationCenterDelegate
0000000100068398 s __OBJC_CLASS_PROTOCOLS_$_NotificationCenterDelegate
00000001000684a8 s __OBJC_CLASS_RO_$_NotificationCenterDelegate
```

With `MACOSX_DEPLOYMENT_TARGET="10.14"` set:
```
~/x/leak_hunting [master +4 ~0 -0 !] ▶ nm ./target/debug/leak_hunting | rg _OBJC_CLASS_
                 U _OBJC_CLASS_$_NSAppleScript
                 U _OBJC_CLASS_$_NSBundle
                 U _OBJC_CLASS_$_NSDate
                 U _OBJC_CLASS_$_NSDictionary
                 U _OBJC_CLASS_$_NSImage
                 U _OBJC_CLASS_$_NSNumber
                 U _OBJC_CLASS_$_NSObject
                 U _OBJC_CLASS_$_NSRunLoop
                 U _OBJC_CLASS_$_NSString
                 U _OBJC_CLASS_$_NSThread
                 U _OBJC_CLASS_$_NSURL
                 U _OBJC_CLASS_$_NSUserNotification
                 U _OBJC_CLASS_$_NSUserNotificationCenter
0000000100068a38 S _OBJC_CLASS_$_NotificationCenterDelegate
0000000100068668 s __OBJC_CLASS_PROTOCOLS_$_NotificationCenterDelegate
0000000100068778 s __OBJC_CLASS_RO_$_NotificationCenterDelegate
```

Additionally, and probably importantly, the dictionary symbols better match what XCode produces with the relevant target versions. @betamos can you try this with Tauri on 10.14/10.13? 