### PR TITLE
Default to no action button

### DIFF
--- a/objc/notify.m
+++ b/objc/notify.m
@@ -81,6 +81,10 @@ NSDictionary* sendNotification(NSString* title, NSString* subtitle, NSString* me
             userNotification.actionButtonTitle = options[@"mainButtonLabel"];
             userNotification.hasActionButton = 1;
         }
+        else
+        {
+            userNotification.hasActionButton = 0;
+        }
 
         // Dropdown actions
         if (options[@"actions"] && ![options[@"actions"] isEqualToString:@""])


### PR DESCRIPTION
This makes it so that no action button is shown by default. Previously, I don't think there was any way to avoid having an action button?

Breaking change for those who want to keep the `Show` button