### PR TITLE
Ensure cross-build compatibility of build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,11 +4,11 @@ use std::env;
 const DEPLOYMENT_TARGET_VAR: &str = "MACOSX_DEPLOYMENT_TARGET";
 
 fn main() {
-    if cfg!(target_os = "macos") {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
         let min_version = match env::var(DEPLOYMENT_TARGET_VAR) {
             Ok(ver) => ver,
             Err(_) => String::from(match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
-                "x86_64" => "10.8", // NSUserNotificationCenter first showed up here.
+                "x86_64" => "10.8",  // NSUserNotificationCenter first showed up here.
                 "aarch64" => "11.0", // Apple silicon started here.
                 arch => panic!("unknown arch: {}", arch),
             }),


### PR DESCRIPTION
This changes make it possible to cross compile for MacOS.