### PR TITLE
fix: wrong type of build flag parameter

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,7 @@ fn main() {
             // `cc` doesn't try to pick up on this automatically, but `clang` needs it to
             // generate a "correct" Objective-C symbol table which better matches XCode.
             // See https://github.com/h4llow3En/mac-notification-sys/issues/45.
-            .flag(format!("-mmacos-version-min={}", min_version))
+            .flag(&format!("-mmacos-version-min={}", min_version))
             .compile("notify");
 
         println!("cargo:rerun-if-env-changed={}", DEPLOYMENT_TARGET_VAR);


### PR DESCRIPTION
rust version: rustc 1.79.0 (129f3b996 2024-06-10)
error details: 
![image](https://github.com/user-attachments/assets/1de4f74d-1a5d-45be-b8bc-0faec294b079)