### PR TITLE
Compatibility fixes for non-Apple clang toolchains

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,17 +15,22 @@ fn main() {
         };
 
         cc::Build::new()
-            .file("objc/notify.m")
+            .file("objc/notify.mm")
             .flag("-fmodules")
             .flag("-Wno-deprecated-declarations")
             // `cc` doesn't try to pick up on this automatically, but `clang` needs it to
             // generate a "correct" Objective-C symbol table which better matches XCode.
             // See https://github.com/h4llow3En/mac-notification-sys/issues/45.
             .flag(format!("-mmacos-version-min={}", min_version))
+            // compatibility with non-Apple clang toolchains
+            .cpp(true)
+            .cpp_set_stdlib("c++")
             .compile("notify");
 
         println!("cargo:rerun-if-env-changed={}", DEPLOYMENT_TARGET_VAR);
         println!("cargo:rerun-if-changed=build.rs");
         println!("cargo:rerun-if-changed=objc");
+        println!("cargo:rustc-link-lib=framework=CoreServices"); // LSCopyApplicationURLsForBundleIdentifier
+        println!("cargo:rustc-link-lib=framework=AppKit"); // NSImage
     }
 }

--- a/objc/notify.h
+++ b/objc/notify.h
@@ -16,10 +16,10 @@ NSString* fakeBundleIdentifier = nil;
 @end
 
 BOOL installNSBundleHook() {
-    Class class = objc_getClass("NSBundle");
-    if (class) {
-        method_exchangeImplementations(class_getInstanceMethod(class, @selector(bundleIdentifier)),
-                                       class_getInstanceMethod(class, @selector(__bundleIdentifier)));
+    Class clazz = objc_getClass("NSBundle");
+    if (clazz) {
+        method_exchangeImplementations(class_getInstanceMethod(clazz, @selector(bundleIdentifier)),
+                                       class_getInstanceMethod(clazz, @selector(__bundleIdentifier)));
         return YES;
     }
     return NO;

--- a/objc/notify.mm
+++ b/objc/notify.mm
@@ -1,7 +1,7 @@
 #import "notify.h"
 
 // getBundleIdentifier(app_name: &str) -> "com.apple.Terminal"
-NSString* getBundleIdentifier(NSString* appName) {
+extern "C" NSString* getBundleIdentifier(NSString* appName) {
     NSString* findString = [NSString stringWithFormat:@"get id of application \"%@\"", appName];
     NSAppleScript* findScript = [[NSAppleScript alloc] initWithSource:findString];
     NSAppleEventDescriptor* resultDescriptor = [findScript executeAndReturnError:nil];
@@ -10,7 +10,7 @@ NSString* getBundleIdentifier(NSString* appName) {
 
 // setApplication(new_bundle_identifier: &str) -> Result<()>
 // invariant: this function should be called at most once and before `sendNotification`
-BOOL setApplication(NSString* newbundleIdentifier) {
+extern "C" BOOL setApplication(NSString* newbundleIdentifier) {
     @autoreleasepool {
         if (!installNSBundleHook()) {
             return NO;
@@ -27,7 +27,7 @@ BOOL setApplication(NSString* newbundleIdentifier) {
 }
 
 // sendNotification(title: &str, subtitle: &str, message: &str, options: Notification) -> NotificationResult<()>
-NSDictionary* sendNotification(NSString* title, NSString* subtitle, NSString* message, NSDictionary* options) {
+extern "C" NSDictionary* sendNotification(NSString* title, NSString* subtitle, NSString* message, NSDictionary* options) {
     @autoreleasepool {
         // For a list of available notification options, see https://developer.apple.com/documentation/foundation/nsusernotification?language=objc
 


### PR DESCRIPTION
This PR fixes compilation and linking issues when using non-Apple clang toolchains such as osxcross or homebrew:

* Enable ObjC++ mode (.mm file) and C++, otherwise non-Apple compilers attempt to compile framework headers in C mode and fail with a lot of errors.
* Explicitly link with CoreServices and AppKit.

I have tested it also using Apple compiler to make sure no compilation regressions are introduced.
