### PR TITLE
Migrate to objc2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,9 @@ include = ["Cargo.toml", "build.rs", "objc/*", "src/*.rs", "tests/*.rs"]
 build = "build.rs"
 
 [dependencies]
-objc-foundation = "0.1.1"
-objc_id = "0.1.1"
+objc2-foundation = "0.3"
+objc2 = "0.6"
 time = "0.3"
-dirs-next = "2.0.0"
 
 [build-dependencies]
 cc = "1.0.17"

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,16 @@
 extern crate cc;
-use std::env;
 
 const DEPLOYMENT_TARGET_VAR: &str = "MACOSX_DEPLOYMENT_TARGET";
 
 fn main() {
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
-        let min_version = match env::var(DEPLOYMENT_TARGET_VAR) {
-            Ok(ver) => ver,
-            Err(_) => String::from(match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
+        let min_version = std::env::var(DEPLOYMENT_TARGET_VAR).unwrap_or_else(|_| {
+            String::from(match std::env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
                 "x86_64" => "10.8",  // NSUserNotificationCenter first showed up here.
-                "aarch64" => "11.0", // Apple silicon started here.
+                "aarch64" => "11.0", // Apple Silicon started here.
                 arch => panic!("unknown arch: {}", arch),
-            }),
-        };
+            })
+        });
 
         cc::Build::new()
             .file("objc/notify.m")

--- a/objc/notify.h
+++ b/objc/notify.h
@@ -5,6 +5,10 @@
 
 NSString* fakeBundleIdentifier = nil;
 
+NSString* getBundleIdentifier(NSString* appName);
+BOOL setApplication(NSString* newbundleIdentifier);
+NSDictionary* sendNotification(NSString* title, NSString* subtitle, NSString* message, NSDictionary* options);
+
 @implementation NSBundle (swizzle)
 - (NSString*)__bundleIdentifier {
     if (self == [NSBundle mainBundle]) {
@@ -15,7 +19,7 @@ NSString* fakeBundleIdentifier = nil;
 }
 @end
 
-BOOL installNSBundleHook() {
+BOOL installNSBundleHook(void) {
     Class class = objc_getClass("NSBundle");
     if (class) {
         method_exchangeImplementations(class_getInstanceMethod(class, @selector(bundleIdentifier)),


### PR DESCRIPTION
This PR migrates from `objc` and `objc-foundation` to `objc2` and `objc2-foundation`. 

I also fixed a couple Clippy and Xcode lints.