### PR TITLE
feat: add support for waiting on notification click

### DIFF
--- a/examples/click.rs
+++ b/examples/click.rs
@@ -1,0 +1,17 @@
+use mac_notification_sys::*;
+
+fn main() {
+    let response = send_notification(
+        "clickable notification",
+        None,
+        "click me",
+        Some(Notification::new().click(true)),
+    )
+    .unwrap();
+
+    if matches!(response, NotificationResponse::Click) {
+        println!("Clicked the notification");
+    } else {
+        println!("No interaction");
+    }
+}

--- a/examples/click.rs
+++ b/examples/click.rs
@@ -5,7 +5,7 @@ fn main() {
         "clickable notification",
         None,
         "click me",
-        Some(Notification::new().click(true)),
+        Some(Notification::new().wait_for_click(true)),
     )
     .unwrap();
 

--- a/objc/notify.h
+++ b/objc/notify.h
@@ -31,6 +31,7 @@ BOOL installNSBundleHook(void) {
 
 @interface NotificationCenterDelegate: NSObject <NSUserNotificationCenterDelegate>
 @property(nonatomic, assign) BOOL keepRunning;
+@property(nonatomic, assign) BOOL click;
 @property(nonatomic, retain) NSDictionary* actionData;
 @end
 
@@ -40,7 +41,7 @@ BOOL installNSBundleHook(void) {
 - (void)userNotificationCenter:(NSUserNotificationCenter*)center
         didDeliverNotification:(NSUserNotification*)notification {
     // Stop running if we're not expecting a response
-    if (!notification.hasActionButton && !notification.hasReplyButton) {
+    if (!notification.hasActionButton && !notification.hasReplyButton && !self.click) {
         self.keepRunning = NO;
     }
 }

--- a/objc/notify.h
+++ b/objc/notify.h
@@ -31,7 +31,7 @@ BOOL installNSBundleHook(void) {
 
 @interface NotificationCenterDelegate: NSObject <NSUserNotificationCenterDelegate>
 @property(nonatomic, assign) BOOL keepRunning;
-@property(nonatomic, assign) BOOL click;
+@property(nonatomic, assign) BOOL waitForClick;
 @property(nonatomic, retain) NSDictionary* actionData;
 @end
 
@@ -41,7 +41,7 @@ BOOL installNSBundleHook(void) {
 - (void)userNotificationCenter:(NSUserNotificationCenter*)center
         didDeliverNotification:(NSUserNotification*)notification {
     // Stop running if we're not expecting a response
-    if (!notification.hasActionButton && !notification.hasReplyButton && !self.click) {
+    if (!notification.hasActionButton && !notification.hasReplyButton && !self.waitForClick) {
         self.keepRunning = NO;
     }
 }

--- a/objc/notify.m
+++ b/objc/notify.m
@@ -104,10 +104,10 @@ NSDictionary* sendNotification(NSString* title, NSString* subtitle, NSString* me
             userNotification.responsePlaceholder = options[@"mainButtonLabel"];
         }
 
-        // Click
+        // Wait for click
         if (options[@"click"] && ![options[@"click"] isEqualToString:@"yes"]) {
             ncDelegate.keepRunning = YES;
-            ncDelegate.click = YES;
+            ncDelegate.waitForClick = YES;
         }
 
         // Change the icon of the app in the notification

--- a/objc/notify.m
+++ b/objc/notify.m
@@ -104,6 +104,12 @@ NSDictionary* sendNotification(NSString* title, NSString* subtitle, NSString* me
             userNotification.responsePlaceholder = options[@"mainButtonLabel"];
         }
 
+        // Click
+        if (options[@"click"] && ![options[@"click"] isEqualToString:@"yes"]) {
+            ncDelegate.keepRunning = YES;
+            ncDelegate.click = YES;
+        }
+
         // Change the icon of the app in the notification
         if (options[@"appIcon"] && ![options[@"appIcon"] isEqualToString:@""]) {
             NSImage* icon = getImageFromURL(options[@"appIcon"]);

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -72,6 +72,7 @@ pub struct Notification<'a> {
     pub(crate) delivery_date: Option<f64>,
     pub(crate) sound: Option<Sound>,
     pub(crate) asynchronous: Option<bool>,
+    pub(crate) click: Option<bool>,
 }
 
 impl<'a> Notification<'a> {
@@ -230,6 +231,19 @@ impl<'a> Notification<'a> {
         self
     }
 
+    /// Allow waiting a response for notification click.
+    ///
+    /// # Example:
+    ///
+    /// ```no_run
+    /// # use mac_notification_sys::*;
+    /// let _ = Notification::new().click(true);
+    /// ```
+    pub fn click(&mut self, click: bool) -> &mut Self {
+        self.click = Some(click);
+        self
+    }
+
     /// Convert the Notification to an Objective C NSDictionary
     pub(crate) fn to_dictionary(&self) -> Retained<NSDictionary<NSString, NSString>> {
         // TODO: If possible, find a way to simplify this so I don't have to manually convert struct to NSDictionary
@@ -243,6 +257,7 @@ impl<'a> Notification<'a> {
             &*NSString::from_str("deliveryDate"),
             &*NSString::from_str("asynchronous"),
             &*NSString::from_str("sound"),
+            &*NSString::from_str("click"),
         ];
         let (main_button_label, actions, is_response): (&str, &[&str], bool) =
             match &self.main_button {
@@ -277,6 +292,11 @@ impl<'a> Notification<'a> {
             }),
             // TODO: Same as above, if NSDictionary could support multiple types, this could be a boolean
             NSString::from_str(match self.asynchronous {
+                Some(true) => "yes",
+                _ => "no",
+            }),
+            // TODO: Same as above, if NSDictionary could support multiple types, this could be a boolean
+            NSString::from_str(match self.click {
                 Some(true) => "yes",
                 _ => "no",
             }),

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -72,7 +72,7 @@ pub struct Notification<'a> {
     pub(crate) delivery_date: Option<f64>,
     pub(crate) sound: Option<Sound>,
     pub(crate) asynchronous: Option<bool>,
-    pub(crate) click: Option<bool>,
+    pub(crate) wait_for_click: Option<bool>,
 }
 
 impl<'a> Notification<'a> {
@@ -237,10 +237,10 @@ impl<'a> Notification<'a> {
     ///
     /// ```no_run
     /// # use mac_notification_sys::*;
-    /// let _ = Notification::new().click(true);
+    /// let _ = Notification::new().wait_for_click(true);
     /// ```
-    pub fn click(&mut self, click: bool) -> &mut Self {
-        self.click = Some(click);
+    pub fn wait_for_click(&mut self, click: bool) -> &mut Self {
+        self.wait_for_click = Some(click);
         self
     }
 
@@ -296,7 +296,7 @@ impl<'a> Notification<'a> {
                 _ => "no",
             }),
             // TODO: Same as above, if NSDictionary could support multiple types, this could be a boolean
-            NSString::from_str(match self.click {
+            NSString::from_str(match self.wait_for_click {
                 Some(true) => "yes",
                 _ => "no",
             }),


### PR DESCRIPTION
This PR solves issue #69. It adds the method `click` to `Notification` for waiting notification click.

Example of usage:
```rust
let response = send_notification(
    "clickable notification",
    None,
    "click me",
    Some(Notification::new().click(true)),
)
.unwrap();
```

The purpose of adding the `click` method to wait for notification click is to ensure backward compatibility. Otherwise, it would block a thread, but the developer might not realize that.