### PR TITLE
Fix macOS 26 compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,6 @@ fn main() {
 
         cc::Build::new()
             .file("objc/notify.m")
-            .flag("-fmodules")
             .flag("-Wno-deprecated-declarations")
             // `cc` doesn't try to pick up on this automatically, but `clang` needs it to
             // generate a "correct" Objective-C symbol table which better matches XCode.


### PR DESCRIPTION
I have no idea how / why, but I figured out that removing the `-fmodules` flag fixes the compilation under macOS 26 for me. Not sure if this may have some other unwanted side effects. 

See: https://github.com/h4llow3En/mac-notification-sys/issues/75#issuecomment-3426548102