### PR TITLE
feat: allow setting showWhenFrontmost

### DIFF
--- a/objc/notify.h
+++ b/objc/notify.h
@@ -9,6 +9,7 @@ NSString* getBundleIdentifier(NSString* appName);
 BOOL setApplication(NSString* newbundleIdentifier);
 void sendNotification(NSString* title, NSString* subtitle, NSString* message, NSDictionary* options, const unsigned char* notificationId, BOOL shouldWait);
 void setupDelegate(void);
+void showWhenFrontmost(BOOL value);
 
 // Rust callbacks — implemented in lib.rs, called from ObjC delegate
 // activationType: 0=none, 1=actionClicked, 2=contentsClicked, 3=replied

--- a/objc/notify.m
+++ b/objc/notify.m
@@ -69,8 +69,14 @@ static void resolveAutoDismiss(const unsigned char* uuid) {
     rust_notification_auto_dismissed(uuid);
 }
 
-// sendNotification — delivers or schedules a notification identified by notificationId (16 bytes).
-// shouldWait: if NO, returns immediately after delivery (fire-and-forget).
+// whether shouldPresentNotification: returns YES (set from Rust before sending)
+static volatile BOOL presentWhenFrontmost = NO;
+
+void showWhenFrontmost(BOOL value) {
+    presentWhenFrontmost = value;
+}
+
+// shouldWait: NO = fire-and-forget, return immediately after delivery
 // if YES, blocks until the user interacts or the notification is auto-dismissed.
 // Result is communicated back to Rust via rust_notification_activated / rust_notification_dismissed /
 // rust_notification_auto_dismissed callbacks.
@@ -240,6 +246,12 @@ void sendNotification(NSString* title, NSString* subtitle, NSString* message, NS
 }
 
 @implementation NotificationCenterDelegate
+
+// force show even when our app is frontmost, otherwise it never enters deliveredNotifications
+- (BOOL)userNotificationCenter:(NSUserNotificationCenter*)center
+     shouldPresentNotification:(NSUserNotification*)notification {
+    return presentWhenFrontmost;
+}
 
 - (void)userNotificationCenter:(NSUserNotificationCenter*)center
         didDeliverNotification:(NSUserNotification*)notification {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ mod sys {
         pub fn setApplication(newbundleIdentifier: *const NSString) -> bool;
         pub fn getBundleIdentifier(appName: *const NSString) -> *const NSString;
         pub fn setupDelegate();
+        pub fn showWhenFrontmost(value: bool);
     }
 }
 
@@ -155,4 +156,15 @@ pub fn set_application(bundle_ident: &str) -> NotificationResult<()> {
         };
     });
     result
+}
+
+/// Show notifications even when our app is frontmost (spoofed bundle ID).
+///
+/// By default `NSUserNotificationCenter` hides notifications for foreground apps
+/// (still *delivered* to `deliveredNotifications` though). Set to `true` to override.
+///
+/// Mainly for CLI tools and libraries spoofing another bundle ID (e.g. Safari)
+/// and getting misidentified as frontmost. Controls *presentation* only, not *delivery*.
+pub fn present_when_frontmost(present: bool) {
+    unsafe { sys::showWhenFrontmost(present) };
 }


### PR DESCRIPTION
will show notifications even if the app is already in the forground